### PR TITLE
fix: AVC denials triggered by playbook_verifier on RHEL 9

### DIFF
--- a/insights_core.te
+++ b/insights_core.te
@@ -282,6 +282,11 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rhcd_read_fifo_files(insights_core_t)
+	rhcd_write_fifo_files(insights_core_t)
+')
+
+optional_policy(`
 	rhsmcertd_domtrans(insights_core_t)
 	rhsmcertd_manage_config_files(insights_core_t)
 	rhsmcertd_manage_lib_files(insights_core_t)


### PR DESCRIPTION
```
time->Thu Aug 14 07:08:19 2025
type=PROCTITLE msg=audit(1755169699.819:639): proctitle=2F7573722F62696E2F707974686F6E33002F7573722F6C69622F707974686F6E332E392F736974652D7061636B616765732F696E7369676874735F636C69656E742F72756E2E7079002D6D00696E7369676874732E636C69656E742E617070732E616E7369626C652E706C6179626F6F6B5F7665726966696572002D2D717569
type=EXECVE msg=audit(1755169699.819:639): argc=9 a0="/usr/bin/python3" a1="/usr/lib/python3.9/site-packages/insights_client/run.py" a2="-m" a3="insights.client.apps.ansible.playbook_verifier" a4="--quiet" a5="--payload" a6="noop" a7="--content-type" a8="noop"
type=SYSCALL msg=audit(1755169699.819:639): arch=c000003e syscall=59 success=yes exit=0 a0=7f3dcf507430 a1=7f3dd0d2f1c0 a2=7f3dcf5d3f30 a3=0 items=0 ppid=23348 pid=23477 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="python3" exe="/usr/bin/python3.9" subj=system_u:system_r:insights_core_t:s0 key=(null)
type=AVC msg=audit(1755169699.819:639): avc:  denied  { write } for  pid=23477 comm="python3" path="pipe:[74708]" dev="pipefs" ino=74708 scontext=system_u:system_r:insights_core_t:s0 tcontext=system_u:system_r:rhcd_t:s0 tclass=fifo_file permissive=0
type=AVC msg=audit(1755169699.819:639): avc:  denied  { write } for  pid=23477 comm="python3" path="pipe:[74707]" dev="pipefs" ino=74707 scontext=system_u:system_r:insights_core_t:s0 tcontext=system_u:system_r:rhcd_t:s0 tclass=fifo_file permissive=0
type=AVC msg=audit(1755169699.819:639): avc:  denied  { read } for  pid=23477 comm="python3" path="pipe:[74706]" dev="pipefs" ino=74706 scontext=system_u:system_r:insights_core_t:s0 tcontext=system_u:system_r:rhcd_t:s0 tclass=fifo_file permissive=0
```

Jira: RHEL-109453 (see also RHEL-99319)