### PR TITLE
add policy systemd_passwd_agent_domtrans

### DIFF
--- a/insights_core.te
+++ b/insights_core.te
@@ -344,6 +344,7 @@ optional_policy(`
     systemd_dbus_chat_timedated(insights_core_t)
     systemd_dbus_chat_localed(insights_core_t)
     systemd_exec_notify(insights_core_t)
+    systemd_passwd_agent_domtrans(insights_core_t)
     systemd_status_all_unit_files(insights_core_t)
     systemd_userdbd_stream_connect(insights_core_t)
 ')


### PR DESCRIPTION
- To fix below AVC denials 
```
avc:  denied  { setfscreate } for comm="systemd-tty-ask" scontext=system_u:system_r:insights_core_t:s0 tcontext=system_u:system_r:insights_core_t:s0 tclass=process permissive=1
avc:  denied  { watch } for comm="systemd-tty-ask" path="/run/systemd/ask-password" scontext=system_u:system_r:insights_core_t:s0 tcontext=system_u:object_r:systemd_passwd_var_run_t:s0 tclass=dir permissive=1
```
- Jira: RHEL-136521