### PR TITLE
Revert "add policy dev_rw_papr_sysparm"

### DIFF
--- a/insights_core.te
+++ b/insights_core.te
@@ -106,7 +106,6 @@ dev_read_netcontrol(insights_core_t)
 dev_read_rand(insights_core_t)
 dev_read_sysfs(insights_core_t)
 dev_rw_lvm_control(insights_core_t)
-dev_rw_papr_sysparm(insights_core_t)
 
 domain_getattr_all_sockets(insights_core_t)
 domain_connect_all_stream_sockets(insights_core_t)


### PR DESCRIPTION
Reverts RedHatInsights/insights-core-selinux#32

Revert it temporary due to cannot reproduce this issue for now.