### PR TITLE
Revert "add policy allow relabelfrom and relabelto"

### DIFF
--- a/insights_core.te
+++ b/insights_core.te
@@ -61,8 +61,6 @@ append_files_pattern(insights_core_t, insights_core_var_log_t, insights_core_var
 create_files_pattern(insights_core_t, insights_core_var_log_t, insights_core_var_log_t)
 logging_log_filetrans(insights_core_t, insights_core_var_log_t, dir)
 
-relabel_dirs_pattern(insights_core_t, insights_core_tmp_t, insights_core_tmp_t)
-relabel_files_pattern(insights_core_t, insights_core_tmp_t, insights_core_tmp_t)
 
 ### Interactions with insights-client
 optional_policy(`


### PR DESCRIPTION
Reverts RedHatInsights/insights-core-selinux#31

Revert it temporary due to cannot reproduce this issue for now.