### PR TITLE
add policy userdom_use_inherited_user_ptys and userdom_watch_tmp_dirs

### DIFF
--- a/insights_core.te
+++ b/insights_core.te
@@ -353,8 +353,10 @@ optional_policy(`
 
 optional_policy(`
     userdom_search_user_tmp_dirs(insights_core_t)
+    userdom_use_inherited_user_ptys(insights_core_t)
     userdom_user_tmp_filetrans(insights_core_t, insights_core_tmp_t, dir)
     userdom_view_all_users_keys(insights_core_t)
+    userdom_watch_tmp_dirs(insights_core_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
- Fix below AVC denials
```
avc:  denied  { watch } for comm="systemd-tty-ask" path="/run/user/0/systemd/ask-password" scontext=system_u:system_r:insights_core_t:s0 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=dir permissive=1
avc:  denied  { read write } for comm="python3" path="/dev/pts/0" scontext=system_u:system_r:insights_core_t:s0 tcontext=unconfined_u:object_r:user_devpts_t:s0 tclass=chr_file permissive=1
```
- Jira: RHEL-136521