### PR TITLE
add policy auth_filetrans_admin_home_content

### DIFF
--- a/insights_core.te
+++ b/insights_core.te
@@ -147,6 +147,7 @@ optional_policy(`
 ')
 
 optional_policy(`
+    auth_filetrans_admin_home_content(insights_core_t)
     auth_read_passwd_file(insights_core_t)
     auth_write_motd_var_run_files(insights_core_t)
 ')


### PR DESCRIPTION
- To fix below AVC denials 
```
---- 
type=PROCTITLE msg=audit(01/30/2026 00:28:28.276:151) : proctitle=python3 /usr/share/ansible/telemetry/telemetry.py 
type=PATH msg=audit(01/30/2026 00:28:28.276:151) : item=1 name=/root/.ansible/tmp/ansible-local-6317hod_7h4w nametype=CREATE cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 
type=PATH msg=audit(01/30/2026 00:28:28.276:151) : item=0 name=/root/.ansible/tmp/ inode=733522 dev=fd:00 mode=dir,700 ouid=root ogid=root rdev=00:00 obj=unconfined_u:object_r:admin_home_t:s0 nametype=PARENT cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 
type=CWD msg=audit(01/30/2026 00:28:28.276:151) : cwd=/ 
type=SYSCALL msg=audit(01/30/2026 00:28:28.276:151) : arch=x86_64 syscall=mkdir success=no exit=EACCES(Permission denied) a0=0x7f3e97fbe230 a1=0700 a2=0x0 a3=0x7f3e99283bec items=2 ppid=6316 pid=6317 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=python3 exe=/usr/bin/python3.9 subj=system_u:system_r:insights_core_t:s0 key=(null) 
type=AVC msg=audit(01/30/2026 00:28:28.276:151) : avc:  denied  { write } for  pid=6317 comm=python3 name=tmp dev=dm-0 ino=733522 scontext=system_u:system_r:insights_core_t:s0 tcontext=unconfined_u:object_r:admin_home_t:s0 tclass=dir permissive=0
```
- Jira: RHINENG-23529