### PR TITLE
new policy firewalld_dbus_chat

### DIFF
--- a/insights_core.te
+++ b/insights_core.te
@@ -189,6 +189,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+    firewalld_dbus_chat(insights_core_t)
+')
+
+optional_policy(`
     fstools_domtrans(insights_core_t)
 ')
 


### PR DESCRIPTION
- Fix below AVC denials
```
type=USER_AVC msg=audit(02/05/2026 03:23:44.396:519) : pid=1755 uid=dbus auid=unset ses=unset subj=system_u:system_r:system_dbusd_t:s0-s0:c0.c1023 msg='avc:  denied  { send_msg } for  scontext=system_u:system_r:insights_core_t:s0 tcontext=system_u:system_r:firewalld_t:s0 tclass=dbus permissive=0 exe=/usr/bin/dbus-broker sauid=dbus hostname=? addr=? terminal=?'
```
- Resolves: RHEL-145614, RHEL-146177